### PR TITLE
Fix download

### DIFF
--- a/src/app/renderengine/render-engine.ts
+++ b/src/app/renderengine/render-engine.ts
@@ -192,7 +192,6 @@ class RenderEngine implements MLayer.INotifyPropertyChanged {
                 oldType = layer.getLayerType();
             }
             layer.render();
-            layer.destroy();
         }
     }
 

--- a/src/app/toolbar/toolbar.logic.js
+++ b/src/app/toolbar/toolbar.logic.js
@@ -19,6 +19,12 @@ app.controller('ToolbarController', ['$scope', '$modal',
       
         /* This functions saves the canvas to an image-file. */
         $scope.saveImage = function() {
+            var toolFunctions = $scope.config.tools.activeToolFunctions;
+
+            if (toolFunctions && toolFunctions.stop) {
+                toolFunctions.stop();
+            }
+
             /* Receive image data in base64 encoding. */
             var image = $scope.renderEngine.renderToImg();
             var data = image.substr(image.indexOf(',') + 1).toString();


### PR DESCRIPTION
Downloaden gefixt:
- Als je tekende en je drukt op download dan wordt wat je net getekend hebt ook meegenomen.
- Render indices probeert niet meer om layers weg te gooien wat ervoor zorgde dat alles kapot ging als je op download drukte